### PR TITLE
fix: AttributeError: collections.abc module not found

### DIFF
--- a/jsonc/__init__.py
+++ b/jsonc/__init__.py
@@ -2,7 +2,7 @@ import json
 import re
 import uuid
 import copy
-import collections
+import typing
 
 __version__ = '1.1.0'
 
@@ -180,7 +180,7 @@ def indexing_decorator(func):
 
     return decorated
 
-class JSONCList(collections.abc.MutableSequence):
+class JSONCList(typing.MutableSequence):
     def __init__(self, data=None, parent=None, key=None):
         if data is None:
             data = []


### PR DESCRIPTION
Importing `MutableSequence` from `typing` instead of `collections.abc`. Solves AttributeError in my case (v1.1.0), which according to #9 should have been fixed in `v1.0.4`.

Thought it could be a python version problem because I'm using a portable installation or because `collections.abc` may have been deprecated in favor or `abc` and `typing`. Well, downloading the repo and running it locally, I even tried to introduce unit tests because why not, but there's no need to, it just works. Yet it raises that error when installed as a package.

Fix #13