### PR TITLE
Enhance JSONC comment handling, formatting preservation, and key-based deletion

### DIFF
--- a/jsonc/__init__.py
+++ b/jsonc/__init__.py
@@ -460,6 +460,7 @@ def dumps(data, indent=4, comments=True):
                     parts = match.group(1).split(',')
                     lines[i] = ','.join(parts[:-1]) + parts[-1] + match.group(2)
 
+    lines[-2] = re.sub(r',(?=\s*//)', '', lines[-2]
     text = '\n'.join(lines)
 
     return text

--- a/jsonc/__init__.py
+++ b/jsonc/__init__.py
@@ -468,7 +468,20 @@ def dumps(data, indent=4, comments=True):
                     parts = match.group(1).split(',')
                     lines[i] = ','.join(parts[:-1]) + parts[-1] + match.group(2)
 
-    lines[-2] = re.sub(r',(?=\s*//)', '', lines[-2])
+    # remove the comma from the last element while keeping track of block comments and keeping inline comments intact
+    in_block_comment = False
+    for i in reversed(range(len(lines))):
+        if in_block_comment:
+            if lines[i].strip().startswith('/*'):
+                in_block_comment = False
+                continue
+        if not in_block_comment:
+            if lines[i].strip().endswith('*/'):
+                in_block_comment = True
+                continue
+            if lines[i].strip() not in ['}', ']', '']:
+                lines[i] = re.sub(r',(?=\s*(//|#))|(,)\s*$', '', lines[i])
+                break
     text = '\n'.join(lines)
 
     return text

--- a/jsonc/__init__.py
+++ b/jsonc/__init__.py
@@ -138,7 +138,7 @@ class JSONCDict(dict):
 
         self.__del_with_comments(key)
 
-        if self.jsonc_parent in not None:
+        if self.jsonc_parent is not None:
             self.jsonc_parent.__delitem__(self.jsonc_key, self)
 
     def __del_with_comments(self, key):

--- a/jsonc/__init__.py
+++ b/jsonc/__init__.py
@@ -460,7 +460,7 @@ def dumps(data, indent=4, comments=True):
                     parts = match.group(1).split(',')
                     lines[i] = ','.join(parts[:-1]) + parts[-1] + match.group(2)
 
-    lines[-2] = re.sub(r',(?=\s*//)', '', lines[-2]
+    lines[-2] = re.sub(r',(?=\s*//)', '', lines[-2])
     text = '\n'.join(lines)
 
     return text


### PR DESCRIPTION
This pull request significantly improves the `jsonc.py` module by enhancing how inline comments and formatting are handled, while also adding native support for dict-like deletion operations.

## Key Enhancements
- Preserves blank lines and formatting when dumping JSONC
- Removes trailing commas before inline comments or at the end of the last element
- Stores inline comments using keys that include the associated JSON field name
- Adds native support for `pop()` and `popitem()` methods
- Ensures all deletion methods (`pop`, `popitem`, `__delitem__`) remove both the data and any associated inline comments

## Commit Summary
1. **Fix:** Remove trailing comma before inline comment  
2. **Fix:** Correct missing closing parenthesis in `re.sub()` expression  
3. **Feat:** Preserve blank lines when dumping JSONC  
4. **Feat:** Include JSON key name in inline comment keys  
5. **Feat:** Add `pop()` and `popitem()` support; unify deletion logic across all methods

## Testing
- All deletion operations verified to cleanly remove both data and comments
- Blank lines are retained in round-tripped files
- JSON remains valid and correctly formatted after edits

This makes the library more robust, human-friendly, and safe for real-world editing and round-tripping of annotated JSONC files.
